### PR TITLE
Update ECS module and enhance security group configurations

### DIFF
--- a/terraform/environments/primary/main.tf
+++ b/terraform/environments/primary/main.tf
@@ -63,6 +63,13 @@ module "jenkins_sg" {
       protocol    = "tcp"
       cidr_blocks = ["0.0.0.0/0"]
     }
+    # Allow SSH from everywhere
+    ssh = {
+      from_port   = 22
+      to_port     = 22
+      protocol    = "tcp"
+      cidr_blocks = ["0.0.0.0/0"]
+    }
   }
 
   # Allow all outbound traffic
@@ -103,6 +110,13 @@ module "monitoring_sg" {
     jaeger = {
       from_port   = 8080
       to_port     = 8080
+      protocol    = "tcp"
+      cidr_blocks = ["0.0.0.0/0"]
+    }
+    # Allow SSH from everywhere
+    ssh = {
+      from_port   = 22
+      to_port     = 22
       protocol    = "tcp"
       cidr_blocks = ["0.0.0.0/0"]
     }
@@ -317,7 +331,7 @@ module "jenkins_asg" {
   desired_capacity = var.asg_desired_capacities["jenkins"]
 
   # Networking from VPC module
-  vpc_zone_identifier = module.vpc.private_subnet_ids
+  vpc_zone_identifier = module.vpc.public_subnet_ids
 
   tags = var.tags
 }
@@ -350,7 +364,7 @@ module "monitoring_asg" {
   desired_capacity = var.asg_desired_capacities["monitoring"]
 
   # Networking from VPC module
-  vpc_zone_identifier = module.vpc.private_subnet_ids
+  vpc_zone_identifier = module.vpc.public_subnet_ids
 
   tags = var.tags
 }

--- a/terraform/modules/ecs/README.md
+++ b/terraform/modules/ecs/README.md
@@ -246,7 +246,7 @@ module "ecs" {
 | network_mode | Network mode for the task definition | string | "awsvpc" | no |
 | requires_compatibilities | Set of launch types required by the task | list(string) | ["FARGATE"] | no |
 | container_definitions | List of container definitions in JSON format or as a list of maps | any | [] | no |
-| create_service | Controls if ECS service should be created | bool | true | no |
+| create_service | Controls if ECS service should be created | bool | false | no |
 | service_name | Name of the ECS service | string | null | no |
 | deployment_maximum_percent | Maximum percentage of tasks that can be running during a deployment | number | 200 | no |
 | deployment_minimum_healthy_percent | Minimum percentage of tasks that must remain healthy during a deployment | number | 100 | no |
@@ -281,7 +281,6 @@ module "ecs" {
 | task_definition_revision | The revision of the Task Definition |
 | service_id | The ID of the ECS service |
 | service_name | The name of the ECS service |
-| service_arn | The ARN of the ECS service |
 | cloudwatch_log_group_arn | The ARN of the CloudWatch log group |
 | cloudwatch_log_group_name | The name of the CloudWatch log group |
 | autoscaling_target_id | The ID of the Application Auto Scaling Target |

--- a/terraform/modules/ecs/outputs.tf
+++ b/terraform/modules/ecs/outputs.tf
@@ -33,17 +33,12 @@ output "task_definition_revision" {
 # Service Outputs
 output "service_id" {
   description = "The ID of the ECS service"
-  value       = var.create_service && var.create_task_definition ? aws_ecs_service.this[0].arn : null
+  value       = var.create_service && var.create_task_definition ? aws_ecs_service.this[0].id : null
 }
 
 output "service_name" {
   description = "The name of the ECS service"
   value       = var.create_service && var.create_task_definition ? aws_ecs_service.this[0].name : null
-}
-
-output "service_arn" {
-  description = "The ARN of the ECS service"
-  value       = var.create_service && var.create_task_definition ? aws_ecs_service.this[0].id : null
 }
 
 # CloudWatch Log Group Outputs

--- a/terraform/modules/ecs/variables.tf
+++ b/terraform/modules/ecs/variables.tf
@@ -119,7 +119,7 @@ variable "container_definitions" {
 variable "create_service" {
   description = "Controls if ECS service should be created"
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "service_name" {


### PR DESCRIPTION
Disable default service creation in the ECS module and add SSH access to security groups while updating the ASG subnet configuration to use public subnets.