### PR TITLE
Fix duplicate name assignment in EFS module configuration

### DIFF
--- a/terraform/environments/dr/main.tf
+++ b/terraform/environments/dr/main.tf
@@ -445,7 +445,6 @@ module "efs" {
   source = "../../modules/efs"
 
   name                  = "${local.name}-efs"
-  name   = "${local.name}-efs"
   vpc_id = module.vpc.vpc_id
 
   subnet_ids         = module.vpc.private_subnet_ids


### PR DESCRIPTION
Remove redundant name assignment in the EFS module to streamline configuration.